### PR TITLE
CHANGE: Use precomputed hash lengths

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+name: 'Rebol-PBKDF2 CI'
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+    paths:
+      - pbkdf2-tests.r3
+      - pbkdf2.reb
+      - scram.reb
+
+  pull_request:
+    branches: [ master ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  CI:
+    strategy:
+      matrix:
+          os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Rebol for the test
+      uses: oldes/install-rebol@v3.18.0
+    
+    - name: Test pbkdf2 module
+      run:  ./rebol3 pbkdf2-tests.r3
+
+    - name: Test scram module
+      run:  ./rebol3 scram-test.r3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![rebol-PBKDF2](https://github.com/user-attachments/assets/0532b0ce-ebd9-49a2-b59e-c304615bbde6)](#)
+[![Rebol-PBKDF2 CI](https://github.com/Oldes/Rebol-PBKDF2/actions/workflows/main.yml/badge.svg)](https://github.com/Oldes/Rebol-PBKDF2/actions/workflows/main.yml)
 
 Rebol-PBKDF2
 =============

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-Rebol2-PBKDF2
+[![rebol-PBKDF2](https://github.com/user-attachments/assets/0532b0ce-ebd9-49a2-b59e-c304615bbde6)](#)
+
+Rebol-PBKDF2
 =============
 
-This is Implementation of PBKDF2 (Password-Based Key Derivation Function 2)  in Rebol 2.
+This is Implementation of PBKDF2 (Password-Based Key Derivation Function 2)  in [Rebol2](http://rebol.com) & [Rebol3](https://github.com/Oldes/Rebol3).
 
 Based on this PHP code, which seemed far the cleanest. https://defuse.ca/php-pbkdf2.htm
 
 Conversion to 4 byte endians uses function from: http://www.codeconscious.com/rebol/tips-and-techniques.html
-
-Should be easy to turn to Rebol3 and Red when the time comes.
 
 
 Status

--- a/pbkdf2.reb
+++ b/pbkdf2.reb
@@ -21,7 +21,7 @@ pbkdf2: function [
     ;; Initialize last block with the salt
     last: copy salt
     ;; Determine the length of the hash output for the selected method
-    hash-len: length? to string! checksum #{} method
+    hash-len: select [sha1 20 sha224 28 sha256 32 sha384 48 sha512 64] :method
     ;; Calculate the number of hash blocks needed to meet the requested length
     block-cnt: round/ceiling (length / hash-len)
 

--- a/scram-test.r3
+++ b/scram-test.r3
@@ -1,0 +1,42 @@
+REBOL [
+    title: "SCRAM Authentication Exchange Test"
+    needs: 3.11.0
+]
+
+import %scram.reb
+
+;; https://datatracker.ietf.org/doc/html/rfc5802#section-5
+state: context [
+    ;; input values...
+    password: "pencil"
+    salt: debase "QSXCR+Q6sek8bf92" 64
+    iterations: 4096
+    method: 'sha1
+    gs2-header: "n,," ;;<-- "biws" as base64 (used in the client-final-message-without-proof)
+    client-first-message-bare: "n=user,r=fyko+d2lbbFgONRv9qkxdawL"
+    server-first-message:      "r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096"
+    client-final-message-without-proof: "c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j"
+    ;; output values...
+    SaltedPassword:
+    ClientKey:
+    ServerKey:
+    StoredKey:
+    AuthMessage:
+    ClientSignature:
+    ServerSignature:
+    ClientProof: none
+]
+
+;; Compute output values using SCRAM and input values in the state object
+scram :state
+;; Display all values in the state object...
+? state
+print ["ClientProof:" state/ClientProof]
+print ["   Expected:" result1: debase "v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=" 64]
+print ["ServerProof:" state/ServerSignature]
+print ["   Expected:" result2: debase "rmF9pqV8S7suAoZWja4dJRkFsKQ=" 64]
+
+if any [
+    result1 <> state/ClientProof
+    result2 <> state/ServerSignature
+][  quit/return 1 ]

--- a/scram.reb
+++ b/scram.reb
@@ -1,0 +1,72 @@
+REBOL [
+    title:  "SCRAM Authentication Exchange"
+    author: @Oldes
+    needs:   3.11.0
+    version: 1.0.0
+    exports: [scram]
+    notes: [
+        https://www.improving.com/thoughts/making-sense-of-scram-sha-256-authentication-in-mongodb/
+        https://datatracker.ietf.org/doc/html/rfc5802
+    ]
+    usage: [
+        ;- SCRAM Authentication Exchange Test                      
+        ;; https://datatracker.ietf.org/doc/html/rfc5802#section-5
+        state: context [
+            ;; input values...
+            password: "pencil"
+            salt: debase "QSXCR+Q6sek8bf92" 64
+            iterations: 4096
+            method: 'sha1
+            gs2-header: "n,," ;;<-- "biws" as base64 (used in the client-final-message-without-proof)
+            client-first-message-bare: "n=user,r=fyko+d2lbbFgONRv9qkxdawL"
+            server-first-message:      "r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096"
+            client-final-message-without-proof: "c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j"
+            ;; output values...
+            SaltedPassword:
+            ClientKey:
+            ServerKey:
+            StoredKey:
+            AuthMessage:
+            ClientSignature:
+            ServerSignature:
+            ClientProof: none
+        ]
+
+        ;; Compute output values using SCRAM and input values in the state object
+        scram :state
+        ;; Display all values in the state object...
+        ? state
+        print ["ClientProof:" state/ClientProof]
+        print ["   Expected:" debase "v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=" 64]
+        print ["ServerProof:" state/ServerSignature]
+        print ["   Expected:" debase "rmF9pqV8S7suAoZWja4dJRkFsKQ=" 64]
+    ]
+]
+
+scram: func [
+    "SCRAM Authentication Exchange"
+    state [object!] "Populated context with input/output values"
+    /local hash-len
+][
+    with state [
+        hash-len: select [sha1 20 sha224 28 sha256 32 sha384 48 sha512 64] :method
+        SaltedPassword: make binary! hash-len
+        hash: join salt #{00000001}
+        hash: SaltedPassword: checksum/with hash :method :password
+        repeat j (iterations - 1) [
+            SaltedPassword: SaltedPassword xor (hash: checksum/with hash :method :password)
+        ]
+        ClientKey: checksum/with "Client Key" :method :SaltedPassword
+        ServerKey: checksum/with "Server Key" :method :SaltedPassword
+        StoredKey: checksum :ClientKey :method
+
+        AuthMessage: rejoin [
+            client-first-message-bare #","
+            server-first-message #","
+            client-final-message-without-proof
+        ]
+        ClientSignature: checksum/with :AuthMessage :method :StoredKey
+        ServerSignature: checksum/with :AuthMessage :method :ServerKey
+        ClientProof: ClientSignature xor ClientKey
+    ]
+]

--- a/scram.reb
+++ b/scram.reb
@@ -46,11 +46,9 @@ REBOL [
 scram: func [
     "SCRAM Authentication Exchange"
     state [object!] "Populated context with input/output values"
-    /local hash-len
 ][
     with state [
-        hash-len: select [sha1 20 sha224 28 sha256 32 sha384 48 sha512 64] :method
-        SaltedPassword: make binary! hash-len
+        SaltedPassword: make binary! 32
         hash: join salt #{00000001}
         hash: SaltedPassword: checksum/with hash :method :password
         loop iterations - 1 [

--- a/scram.reb
+++ b/scram.reb
@@ -53,7 +53,7 @@ scram: func [
         SaltedPassword: make binary! hash-len
         hash: join salt #{00000001}
         hash: SaltedPassword: checksum/with hash :method :password
-        repeat j (iterations - 1) [
+        loop iterations - 1 [
             SaltedPassword: SaltedPassword xor (hash: checksum/with hash :method :password)
         ]
         ClientKey: checksum/with "Client Key" :method :SaltedPassword

--- a/scram.reb
+++ b/scram.reb
@@ -46,6 +46,7 @@ REBOL [
 scram: func [
     "SCRAM Authentication Exchange"
     state [object!] "Populated context with input/output values"
+    /local hash ;; not needed in the state
 ][
     with state [
         SaltedPassword: make binary! 32


### PR DESCRIPTION
It's more optimal to use precomputed lengths...
```
Running 2 code blocks 10 times.
----------------------------------------------------------------------------------------------------------------------------------
Time               | Evals  | S.made | S.expa | Memory      | Code
1.0x (900ns)       | 2      | 0      | 0      | 0           | [select [sha1 20 sha224 28 sha256 32 sha384 48 sha512 64] 'sha512]
2.44x (2μs)        | 3      | 1      | 0      | 64          | [length? checksum #{} 'sha512]
----------------------------------------------------------------------------------------------------------------------------------
```